### PR TITLE
Add vcpkg.json to project root

### DIFF
--- a/chapter_5/find_module/CMakeLists.txt
+++ b/chapter_5/find_module/CMakeLists.txt
@@ -20,7 +20,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 # try to find the package obscure see the file cmake/FindObscure.cmake for the innner workings
 find_package(Obscure QUIET)
 
-if(NOT obscure_FOUND)
+if(NOT Obscure_FOUND)
     message(STATUS "Prebuilt library 'obscure' not found, skipping find module example")
     return()
 endif()

--- a/chapter_5/find_module/cmake/FindObscure.cmake
+++ b/chapter_5/find_module/cmake/FindObscure.cmake
@@ -7,14 +7,14 @@ find_library(
     OBSCURE_LIBRARY
     NAMES obscure 
     HINTS ${PROJECT_SOURCE_DIR}/dep/ ${CMAKE_CURRENT_BINARY_DIR}/dep
-    PATH_SUFFIXES lib bin build/Release build/Debug
+    PATH_SUFFIXES lib bin build/Release build/Debug 
 )
 
 # find the main header belonging to the obscure lib
 find_path(
     OBSCURE_INCLUDE_DIR
     NAMES obscure/obscure.hpp
-    HINTS ${PROJECT_SOURCE_DIR}/dep/include/ ${CMAKE_CURRENT_BINARY_DIR}/dep/include
+    HINTS ${PROJECT_SOURCE_DIR}/dep/include/ ${CMAKE_CURRENT_BINARY_DIR}/dep/include ${CMAKE_CURRENT_SOURCE_DIR}/dep_source/include
 )
 
 # use the FindPackageHandleStandardArgs to check if everything was found

--- a/chapter_5/vcpkg_example/src/main.cpp
+++ b/chapter_5/vcpkg_example/src/main.cpp
@@ -1,11 +1,12 @@
 #include <rapidjson/document.h>
+#include <iostream>
 
 int main(int, char**) {
 
   const char json[] = " { \"hello\" : \"world\", \"t\" : true , \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3, 4] } ";
   
   rapidjson::Document document; 
-  document.parse(json);
+  document.Parse(json);
 
   if(document.HasMember("hello"))
   {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,9 @@
+{
+    "name" : "vcpkg-example",
+    "version-semver" : "0.0.1",
+    "dependencies" :
+    [
+        "rapidjson"
+    ]
+
+}


### PR DESCRIPTION
The TR remarked that using VCPKG in manifest mode does not work on the root, because the manifest file is not found and that the example did not compile correctly