### PR TITLE
Building/fixing pytest

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM conanio/gcc11:1.44.1
 
-RUN pip install cmake-format pytest
+RUN pip3 install cmake-format pytest pytest-depends cpplint 
 
 # switch to root
 USER root
@@ -11,8 +11,6 @@ RUN  apt-get update; \
     gdb curl bash-completion vim rpm \
     graphviz python3-pytest doxygen plantuml gcovr \
     clang-tidy cppcheck iwyu zip afl++ clang-format ccache
-
-RUN pip3 install cpplint
 
 # Download version 3.21 from CMake
 RUN curl -OL https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-linux-x86_64.sh

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM conanio/gcc11:1.44.1
 
-RUN pip install cmake-format
+RUN pip install cmake-format pytest
 
 # switch to root
 USER root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: install-python-deps
         run: |
           python3 -m pip install --upgrade pip
-          pip3 install pytest conan cpplint
+          pip3 install pytest pytest-depends conan cpplint 
 
       - name: set-compiler-env
         run: |

--- a/tests/chapter4_functional_test.py
+++ b/tests/chapter4_functional_test.py
@@ -103,16 +103,19 @@ class TestChapter4():
         """
         assert run_cmake("-S", self.source_directory, "-B", self.temporary_build_root)
 
+    @pytest.mark.depends(on=['test_configure'])
     def test_build(self):
         """Check if project can be built
         """
         assert run_cmake("--build", self.temporary_build_root, *CMAKE_COMMAND_MULTICONFIG_ARGS,  "--parallel", str(os.cpu_count()))
 
+    @pytest.mark.depends(on=['test_configure'])
     def test_install(self):
         """Check if project can be installed
         """
         assert run_cmake("--install", self.temporary_build_root, *CMAKE_COMMAND_MULTICONFIG_ARGS, "--prefix", self.temporary_install_root)
 
+    @pytest.mark.depends(on=['test_install'])
     def test_install_check_files_exists(self):
         """Check if install step has installed the all files that install() commands intend to install
         """
@@ -138,12 +141,14 @@ class TestChapter4():
         assert file_exists(f"{self.temporary_install_root}/cmake/ch4_ex05_lib-config.cmake")
         assert file_exists(f"{self.temporary_install_root}/cmake/ch4_ex05_lib-config-version.cmake")
     
+    @pytest.mark.depends(on=['test_configure'])    
     def test_install_run_binaries(self):
         """Try to run executables that installed via install
         """
         assert run_command(f"{self.temporary_install_root}/bin/ch4_ex01_executable{PLATFORM_EXECUTABLE_EXTENSION}")
         assert run_command("python3", f"{self.temporary_install_root}/bin/chapter4_greeter")
 
+    @pytest.mark.depends(on=['test_configure'])
     def test_ex05_consumer(self):
         """Check config-file package works by building ex05_consumer after installing the chapter 4 content
         """
@@ -168,23 +173,27 @@ class TestChapter4Example6():
         """Check if project can be configured
         """
         assert run_cmake("-S", self.source_directory, "-B", self.temporary_build_root)
-
+    
+    @pytest.mark.depends(on=['test_configure'])
     def test_configure_check_files(self):
         """Check if CPack configuration files are present after configuration 
         """
         assert file_exists(f"{self.temporary_build_root}/CPackConfig.cmake")
         assert file_exists(f"{self.temporary_build_root}/CPackSourceConfig.cmake")
 
+    @pytest.mark.depends(on=['test_configure'])
     def test_build(self):
         """Check if project can be built
         """
         assert run_cmake("--build", self.temporary_build_root, *CMAKE_COMMAND_MULTICONFIG_ARGS,  "--parallel", str(os.cpu_count()))
 
+    @pytest.mark.depends(on=['test_configure'])
     def test_install(self):
         """Check if project can be installed
         """
         assert run_cmake("--install", self.temporary_build_root, *CMAKE_COMMAND_MULTICONFIG_ARGS, "--prefix", self.temporary_install_root)
 
+    @pytest.mark.depends(on=['test_install'])
     def test_install_check_files(self):
         """Check if install step has installed the all files that install() commands intend to install
         """
@@ -192,17 +201,19 @@ class TestChapter4Example6():
         assert file_exists(f"{self.temporary_install_root}/lib/{PLATFORM_STATIC_LIBRARY_PREFIX}ch4_ex06_library{PLATFORM_STATIC_LIBRARY_EXTENSION}")
         assert file_exists(f"{self.temporary_install_root}/include/chapter4/ex06/lib.hpp")
 
+    @pytest.mark.depends(on=['test_install'])
     def test_install_run_binaries(self):
         """Try to run executables that installed via install
         """
         assert run_command(f"{self.temporary_install_root}/bin/ch4_ex06_executable{PLATFORM_EXECUTABLE_EXTENSION}")
 
-
+    @pytest.mark.depends(on=['test_configure'])
     def test_pack(self):
         """Try to pack the project via CPack
         """
         assert run_cpack("--config", f"{self.temporary_build_root}/CPackConfig.cmake", *CPACK_COMMAND_MULTICONFIG_ARGS, "-G", "TGZ", "-B", f"{self.temporary_build_root}/pak")
 
+    @pytest.mark.depends(on=['test_pack'])
     def test_pack_check_files(self):
         """Check whether CPack produced the package files
         """

--- a/tests/chapter4_functional_test.py
+++ b/tests/chapter4_functional_test.py
@@ -9,6 +9,7 @@ import pytest
 import tempfile
 import os
 import sys
+import glob
 from pathlib import Path
 from os.path import exists as file_exists
 
@@ -119,10 +120,21 @@ class TestChapter4():
     def test_install_check_files_exists(self):
         """Check if install step has installed the all files that install() commands intend to install
         """
+    
+        # Print install folder contents if an assert fails to make debugging easier
+        for root, subdirs, files in os.walk(self.temporary_install_root):
+            print('--\nroot = ' + root)
+            for s in subdirs:
+                print('\tdirs-- ' + s)
+            for f in files:
+                print('\t\t files-- ' + f)
+        
         # Example 1
         assert file_exists(f"{self.temporary_install_root}/bin/ch4_ex01_executable{PLATFORM_EXECUTABLE_EXTENSION}")
         # Example 2
-        assert file_exists(f"{self.temporary_install_root}/lib/{PLATFORM_STATIC_LIBRARY_PREFIX}ch4_ex02_static{PLATFORM_STATIC_LIBRARY_EXTENSION}")
+        # use globbing to account for platform-tuple suffixes i.e. lib/x64_86-linux-gnu etc
+        assert len(glob.glob(f"{self.temporary_install_root}/lib/**/{PLATFORM_STATIC_LIBRARY_PREFIX}ch4_ex02_static{PLATFORM_STATIC_LIBRARY_EXTENSION}", recursive=True)) > 0
+        
         assert file_exists(f"{self.temporary_install_root}/include/chapter4/ex02/lib.hpp")
         # Example 3
         assert file_exists(f"{self.temporary_install_root}/bin/chapter4_greeter_content")
@@ -136,7 +148,8 @@ class TestChapter4():
         assert file_exists(f"{self.temporary_install_root}/var/dir3/asset4")
         assert not file_exists(f"{self.temporary_install_root}/var/dir3/bin/goodbye.dat")
         # Example 5
-        assert file_exists(f"{self.temporary_install_root}/lib/{PLATFORM_STATIC_LIBRARY_PREFIX}ch4_ex05_lib{PLATFORM_STATIC_LIBRARY_EXTENSION}")
+        assert len(glob.glob(f"{self.temporary_install_root}/lib/**/{PLATFORM_STATIC_LIBRARY_PREFIX}ch4_ex05_lib{PLATFORM_STATIC_LIBRARY_EXTENSION}", recursive=True)) > 0
+        
         assert file_exists(f"{self.temporary_install_root}/include/chapter4/ex05/lib.hpp")
         assert file_exists(f"{self.temporary_install_root}/cmake/ch4_ex05_lib-config.cmake")
         assert file_exists(f"{self.temporary_install_root}/cmake/ch4_ex05_lib-config-version.cmake")
@@ -198,7 +211,8 @@ class TestChapter4Example6():
         """Check if install step has installed the all files that install() commands intend to install
         """
         assert file_exists(f"{self.temporary_install_root}/bin/ch4_ex06_executable{PLATFORM_EXECUTABLE_EXTENSION}")
-        assert file_exists(f"{self.temporary_install_root}/lib/{PLATFORM_STATIC_LIBRARY_PREFIX}ch4_ex06_library{PLATFORM_STATIC_LIBRARY_EXTENSION}")
+        # use globbing to account for platform-tuple suffixes i.e. lib/x64_86-linux-gnu etc
+        assert len(glob.glob(f"{self.temporary_install_root}/lib/**/{PLATFORM_STATIC_LIBRARY_PREFIX}ch4_ex06_library{PLATFORM_STATIC_LIBRARY_EXTENSION}", recursive=True)) > 0
         assert file_exists(f"{self.temporary_install_root}/include/chapter4/ex06/lib.hpp")
 
     @pytest.mark.depends(on=['test_install'])


### PR DESCRIPTION
Fixed the failing test. For some reason cmake started appending the platform tuple (x86_64-linux-gnu etc) to the installation path for static libraries. 

I currently do not know what caused the change in behavior. However the test use now glob to find the static libraries in any subfolder of the `lib` dir