### PR TITLE
Fix: Unable to Find Any Test Cases in CMake

### DIFF
--- a/chapter07/test_discovery_example/CMakeLists.txt
+++ b/chapter07/test_discovery_example/CMakeLists.txt
@@ -15,10 +15,11 @@ project(
 include(FetchContent)
 FetchContent_Declare(Catch2 
                      GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-                     GIT_TAG        v2.13.1)
+                     GIT_TAG        v2.13.8)
 
 FetchContent_MakeAvailable(Catch2)             
 list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/contrib/)
+include(CTest)
 include(Catch)
 
 add_executable(ch7_test_discovery_example)


### PR DESCRIPTION
This commit addresses an issue where CMake was unable to locate any test cases. The problem was caused by missing the `include(CTest)` statement. Additionally, Catch2 v2.13.1 cannot compile with gcc 11.4.0, so we've upgraded to v2.13.8.

Impact:
- Tests can now be discovered and executed successfully.